### PR TITLE
change text color for react-select multi CreatableSelect

### DIFF
--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -261,6 +261,7 @@ export function selectFieldStyle(theme: Theme) {
     valueContainer: (provided: any) => ({
       ...provided,
       cursor: "text",
+      color: theme.text,
     }),
   }
 }


### PR DESCRIPTION
The presenter and contributor fields in the metadata tab use a combined select input control with multi-select enabled. When typing the text is hardly visible in the dark theme, as it's grey on a dark background.

This commit sets the color on the `valueContainer` component to `theme.text` to respect the theme selection.

For the list of available components for React-Select see: https://react-select.com/components

Fixes: #813
Signed-off-by: Daniel Ziegenberg <daniel@ziegenberg.at>